### PR TITLE
nbproject/private folder should (hopefully) be ignored now.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /ChargerSnake/build/
-/ChargerSnake/nbproject/private/
+/ChargerSnake/nbproject/private/*
 /ChargerSnake/dist/


### PR DESCRIPTION
(Hopefully) fixed the problem of the nbproject/private folder and its contents being grabbed despite being in the gitignore.